### PR TITLE
option for integration into Apache using mod_wsgi

### DIFF
--- a/indiweb/database.py
+++ b/indiweb/database.py
@@ -23,7 +23,7 @@ class Database(object):
         else:
             logging.info("Created directory %s" % db_dir)
 
-        self.__conn = sqlite3.connect(filename)
+        self.__conn = sqlite3.connect(filename, check_same_thread=False)
         self.__conn.row_factory = dict_factory
 
         # create new tables if they doesn't exist

--- a/indiweb/indi_server.py
+++ b/indiweb/indi_server.py
@@ -7,7 +7,10 @@ import psutil
 
 INDI_PORT = 7624
 INDI_FIFO = '/tmp/indiFIFO'
-INDI_CONFIG_DIR = os.path.join(os.environ['HOME'], '.indi')
+try:
+    INDI_CONFIG_DIR = os.path.join(os.environ['HOME'], '.indi')
+except KeyError as e:
+    INDI_CONFIG_DIR = '/tmp/indi'
 
 
 class IndiServer(object):
@@ -56,9 +59,13 @@ class IndiServer(object):
             self.start_driver(driver)
 
     def stop(self):
-        cmd = ['pkill', 'indiserver']
+        cmd = ['pkill', '-9', 'indiserver']
         logging.info(' '.join(cmd))
-        call(cmd)
+        ret = call(cmd)
+        if ret == 0:
+            logging.info('indiserver terminated successfully')
+        else:
+            logging.warn('terminating indiserver failed code ' + str(ret))
 
     def is_running(self):
         for proc in psutil.process_iter():


### PR DESCRIPTION
With this change it is possible to integrate the indiwebmanager into an Apache web server.

This requires that the mod_wsgi module is installed for Apache (libapache2-mod-wsgi-py3 for python3 or libapache2-mod-wsgi for python2.7)

For enabling indiwebmanager, copy indiweb.conf into /etc/apache2/sites-available, adapt the python path and enable the new site.

After reloading Apache, the indiwebmanager will be available under http://localhost:8080/

Cheers
Wolfgang