### PR TITLE
Restarting single drivers

### DIFF
--- a/indiweb.conf
+++ b/indiweb.conf
@@ -3,7 +3,11 @@ Listen 8080
 
     CustomLog ${APACHE_LOG_DIR}/indiweb_access.log combined
     LogLevel info
-    
+
+    # run the python processes as user "indi"
+    WSGIDaemonProcess indiweb user=indi processes=1 threads=5 display-name=%{GROUP}
+    WSGIProcessGroup indiweb    
+
     # change the path if your indiweb installation is somewhere else
     WSGIScriptAlias / /usr/local/lib/python2.7/dist-packages/indiweb/indiweb.wsgi
     # directory containing indiweb

--- a/indiweb.wsgi
+++ b/indiweb.wsgi
@@ -2,7 +2,7 @@ import sys
 import bottle
 
 # add this, if you have the indiwebmanager installed in a separate place
-# sys.path.insert(0, '<path to indiwebmanager')
+# sys.path.insert(0, '<path to indiwebmanager>')
 
 sys.argv += ['-v', '--server', 'apache', '-l', '/tmp/wsgi.log']
 

--- a/indiweb.wsgi
+++ b/indiweb.wsgi
@@ -4,6 +4,8 @@ import bottle
 # add this, if you have the indiwebmanager installed in a separate place
 # sys.path.insert(0, '<path to indiwebmanager')
 
+sys.argv += ['-v', '--server', 'apache', '-l', '/tmp/wsgi.log']
+
 application = bottle.default_app()
 
 import indiweb.main

--- a/indiweb/indi_server.py
+++ b/indiweb/indi_server.py
@@ -48,6 +48,18 @@ class IndiServer(object):
         logging.info(full_cmd)
         call(full_cmd, shell=True)
 
+    def stop_driver(self, driver):
+        # escape quotes if they exist
+        cmd = 'stop %s"' % driver.binary
+
+        if "@" not in driver.binary:
+            cmd += ' -n "%s"' % driver.label
+
+        cmd = cmd.replace('"', '\\"')
+        full_cmd = 'echo "%s" > %s' % (cmd, self.__fifo)
+        logging.info(full_cmd)
+        call(full_cmd, shell=True)
+
     def start(self, port=INDI_PORT, drivers=[]):
         if self.is_running():
             self.stop()

--- a/indiweb/indi_server.py
+++ b/indiweb/indi_server.py
@@ -49,7 +49,6 @@ class IndiServer(object):
         call(full_cmd, shell=True)
         self.__running_drivers[driver.label] = driver
 
-
     def stop_driver(self, driver):
         # escape quotes if they exist
         cmd = 'stop %s' % driver.binary

--- a/indiweb/indi_server.py
+++ b/indiweb/indi_server.py
@@ -27,7 +27,7 @@ class IndiServer(object):
         call(['mkfifo', self.__fifo])
 
     def __run(self, port):
-        cmd = 'indiserver -p %d -m 100 -v -f %s > /dev/null 2>&1 &' % \
+        cmd = 'indiserver -p %d -m 100 -v -f %s > /tmp/indiserver.log 2>&1 &' % \
             (port, self.__fifo)
         logging.info(cmd)
         call(cmd, shell=True)
@@ -47,10 +47,12 @@ class IndiServer(object):
         full_cmd = 'echo "%s" > %s' % (cmd, self.__fifo)
         logging.info(full_cmd)
         call(full_cmd, shell=True)
+        self.__running_drivers[driver.label] = driver
+
 
     def stop_driver(self, driver):
         # escape quotes if they exist
-        cmd = 'stop %s"' % driver.binary
+        cmd = 'stop %s' % driver.binary
 
         if "@" not in driver.binary:
             cmd += ' -n "%s"' % driver.label
@@ -59,6 +61,7 @@ class IndiServer(object):
         full_cmd = 'echo "%s" > %s' % (cmd, self.__fifo)
         logging.info(full_cmd)
         call(full_cmd, shell=True)
+        del self.__running_drivers[driver.label]
 
     def start(self, port=INDI_PORT, drivers=[]):
         if self.is_running():
@@ -66,6 +69,7 @@ class IndiServer(object):
 
         self.__clear_fifo()
         self.__run(port)
+        self.__running_drivers = {}
 
         for driver in drivers:
             self.start_driver(driver)
@@ -98,6 +102,7 @@ class IndiServer(object):
         return self.get_prop(dev, prop, '_STATE')
 
     def get_running_drivers(self):
-        drivers = [proc.name() for proc in psutil.process_iter() if
-                   proc.name().startswith('indi_')]
+        # drivers = [proc.name() for proc in psutil.process_iter() if
+        #            proc.name().startswith('indi_')]
+        drivers = self.__running_drivers
         return drivers

--- a/indiweb/main.py
+++ b/indiweb/main.py
@@ -244,6 +244,32 @@ def get_json_drivers():
     response.content_type = 'application/json'
     return json.dumps([ob.__dict__ for ob in collection.drivers])
 
+@app.post('/api/drivers/start/<label>')
+def start_driver(label):
+    """Start INDI driver"""
+    driver = collection.by_label(label)
+    indi_server.start_driver(driver)
+    logging.info('Driver "%s" started.' % label)
+
+@app.post('/api/drivers/stop/<label>')
+def stop_driver(label):
+    """Stop INDI driver"""
+    driver = collection.by_label(label)
+    indi_server.stop_driver(driver)
+    logging.info('Driver "%s" stopped.' % label)
+
+@app.post('/api/drivers/restart/<label>')
+def restart_driver(label):
+    """Restart INDI driver"""
+    driver = collection.by_label(label)
+    indi_server.stop_driver(driver)
+    indi_server.start_driver(driver)
+    logging.info('Driver "%s" restarted.' % label)
+
+
+###############################################################################
+# Startup standalone server
+###############################################################################
 
 def main():
     """Start autostart profile if any"""

--- a/indiweb/main.py
+++ b/indiweb/main.py
@@ -254,7 +254,7 @@ def main():
             active_profile = profile['name']
             break
 
-    run(application, host=args.host, port=args.port, quiet=not args.verbose)
+    run(app, host=args.host, port=args.port, quiet=args.verbose)
     logging.info("Exiting")
 
 

--- a/indiweb/main.py
+++ b/indiweb/main.py
@@ -4,7 +4,6 @@ import os
 import json
 import logging
 import argparse
-import bottle
 from bottle import Bottle, run, template, static_file, request, response, default_app
 from .indi_server import IndiServer, INDI_PORT, INDI_FIFO, INDI_CONFIG_DIR
 from .driver import DeviceDriver, DriverCollection, INDI_DATA_DIR
@@ -50,10 +49,12 @@ if args.verbose:
     logging_level = logging.DEBUG
 
 if args.logfile:
-    logging.basicConfig(filename=args.logfile, format='%(asctime)s - %(levelname)s: %(message)s', level=logging_level)
+    logging.basicConfig(filename=args.logfile,
+                        format='%(asctime)s - %(levelname)s: %(message)s',
+                        level=logging_level)
 else:
-    logging.basicConfig(format='%(asctime)s - %(levelname)s: %(message)s', level=logging_level)
-    
+    logging.basicConfig(format='%(asctime)s - %(levelname)s: %(message)s',
+                        level=logging_level)
 
 logging.debug("command line arguments: " + str(vars(args)))
 
@@ -248,6 +249,7 @@ def get_json_drivers():
     response.content_type = 'application/json'
     return json.dumps([ob.__dict__ for ob in collection.drivers])
 
+
 @app.post('/api/drivers/start/<label>')
 def start_driver(label):
     """Start INDI driver"""
@@ -255,12 +257,14 @@ def start_driver(label):
     indi_server.start_driver(driver)
     logging.info('Driver "%s" started.' % label)
 
+
 @app.post('/api/drivers/stop/<label>')
 def stop_driver(label):
     """Stop INDI driver"""
     driver = collection.by_label(label)
     indi_server.stop_driver(driver)
     logging.info('Driver "%s" stopped.' % label)
+
 
 @app.post('/api/drivers/restart/<label>')
 def restart_driver(label):

--- a/indiweb/main.py
+++ b/indiweb/main.py
@@ -194,10 +194,14 @@ def get_server_status():
 @app.get('/api/server/drivers')
 def get_server_drivers():
     """List server drivers"""
-    status = []
-    for driver in indi_server.get_running_drivers():
-        status.append({'driver': driver})
-    return json.dumps(status)
+    # status = []
+    # for driver in indi_server.get_running_drivers():
+    #     status.append({'driver': driver})
+    # return json.dumps(status)
+    labels = []
+    for label in sorted(indi_server.get_running_drivers().keys()):
+        labels.append({'driver': label})
+    return json.dumps(labels)
 
 
 @app.post('/api/server/start/<profile>')

--- a/indiweb/views/js/indi.js
+++ b/indiweb/views/js/indi.js
@@ -282,13 +282,12 @@ function getActiveDrivers() {
 
 
 function restartDriver(label) {
-    console.log("restarting " + label)
         $.ajax({
             type: 'POST',
             url: "/api/drivers/restart/" + label,
             success: function() {
                 getStatus();
-		$("#notify_message").html('<br/><div class="alert alert-success"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Restarting driver "' + label + '" succeeded.</div>')
+		$("#notify_message").html('<br/><div class="alert alert-success"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Restarting driver "' + label + '" succeeded.</div>');
             },
             error: function() {
                 alert('Restarting driver "' + label + '" failed!');

--- a/indiweb/views/js/indi.js
+++ b/indiweb/views/js/indi.js
@@ -257,10 +257,14 @@ function getStatus() {
 function getActiveDrivers() {
     $.getJSON("/api/server/drivers", function(data) {
         $("#server_command").html("<span class='glyphicon glyphicon-cog' aria-hidden='true'></span> Stop");
-        var msg = "<p class='alert alert-info'>Server is Online.<ul>";
+        var msg = "<p class='alert alert-info'>Server is Online.<ul  class=\"list-unstyled\">";
         var counter = 0;
         $.each(data, function(i, field) {
-            msg += "<li>" + field.driver + "</li>";
+            msg += "<li>" + "<button class=\"btn btn-xs\" " +
+		"onCLick=\"restartDriver('" + field.driver + "')\" data-toggle=\"tooltip\" " +
+		"title=\"Restart Driver\">" +
+		"<span class=\"glyphicon glyphicon-repeat\" aria-hidden=\"true\"></span></button> " +
+		field.driver + "</li>";
             counter++;
         });
 
@@ -275,3 +279,19 @@ function getActiveDrivers() {
     });
 
 }
+
+
+function restartDriver(label) {
+    console.log("restarting " + label)
+        $.ajax({
+            type: 'POST',
+            url: "/api/drivers/restart/" + label,
+            success: function() {
+                getStatus();
+		$("#notify_message").html('<br/><div class="alert alert-success"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Restarting driver "' + label + '" succeeded.</div>')
+            },
+            error: function() {
+                alert('Restarting driver "' + label + '" failed!');
+            }
+        });
+ }


### PR DESCRIPTION
I added the option to restart single drivers - see added screenshot. This contains the following changes:
- Instead of listing running "indi_..." processes, we hold the list of active INDI drivers inside of the indiwebmanager status.
- Active drivers are displayed by their label and not by the binary name
- Add a "restart" button for each active driver
- Add new routes in main.py for starting, stopping and restarting a single driver.

Wolfgang

<img width="1179" alt="restarting an INDI driver" src="https://user-images.githubusercontent.com/37261405/40387893-49e0e9fe-5e0e-11e8-9834-c64528b412cc.png">