### PR TITLE
bug fix for remote driver calls

### DIFF
--- a/indiweb/indi_server.py
+++ b/indiweb/indi_server.py
@@ -34,11 +34,11 @@ class IndiServer(object):
 
     def start_driver(self, driver):
         # escape quotes if they exist
-        conf = os.path.join(self.__conf_dir, driver.label + '_config.xml')
-        cmd = 'start %s -c "%s"' % (driver.binary, conf)
+        cmd = 'start %s' % driver.binary
 
         if "@" not in driver.binary:
-            cmd += ' -n "%s"' % driver.label
+            conf = os.path.join(self.__conf_dir, driver.label + '_config.xml')
+            cmd += ' -c "%s" -n "%s"' % (conf, driver.label)
 
         if driver.skeleton:
             cmd += ' -s "%s"' % driver.skeleton


### PR DESCRIPTION
Attaching devices mounted on a remote indiserver instance failed. The problem was that the call in indi_server.py tried to call a remote device holding a config file setting. But for remote devices, indiserver only accepts `<device label>@<remote host>`.