### PR TITLE
Do not set config file for startup, leave decision to driver

### DIFF
--- a/indiweb/indi_server.py
+++ b/indiweb/indi_server.py
@@ -36,10 +36,6 @@ class IndiServer(object):
         # escape quotes if they exist
         cmd = 'start %s' % driver.binary
 
-        if "@" not in driver.binary:
-            conf = os.path.join(self.__conf_dir, driver.label + '_config.xml')
-            cmd += ' -c "%s" -n "%s"' % (conf, driver.label)
-
         if driver.skeleton:
             cmd += ' -s "%s"' % driver.skeleton
 


### PR DESCRIPTION
At least with my Optec FocusLynx, setting the config file during driver startup creates problems, FocusLynx uses two config files, one for each focuser connection. If it is started with a given config file, both configs are written to the same config file. As a result, the last one wins.

Does it really make sense setting the config file? Or should this be left to the driver to decide?