### PR TITLE
Display the hostname in heading and title

### DIFF
--- a/indiweb/main.py
+++ b/indiweb/main.py
@@ -4,6 +4,7 @@ import os
 import json
 import logging
 import argparse
+import socket
 from threading import Timer
 
 from bottle import Bottle, run, template, static_file, request, response, BaseRequest, default_app
@@ -127,8 +128,10 @@ def main_form():
         saved_profile = request.get_cookie('indiserver_profile') or 'Simulators'
 
     profiles = db.get_profiles()
+    hostname = socket.gethostname()
     return template(os.path.join(views_path, 'form.tpl'), profiles=profiles,
-                    drivers=drivers, saved_profile=saved_profile)
+                    drivers=drivers, saved_profile=saved_profile,
+                    hostname=hostname)
 
 ###############################################################################
 # Profile endpoints

--- a/indiweb/views/form.tpl
+++ b/indiweb/views/form.tpl
@@ -1,3 +1,4 @@
+% import socket
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -8,7 +9,7 @@
 
   <!-- Set the page to the width of the device and set the zoon level -->
   <meta name="viewport" content="width = device-width, initial-scale = 1">
-  <title>INDI Web Manager</title>
+  <title>{{hostname}} INDI Web Manager</title>
   <link rel="stylesheet" type="text/css" href="/static/css/bootstrap.min.css">
   <link rel="stylesheet" type="text/css" href="/static/css/jquery-ui.min.css">
   <link rel="stylesheet" type="text/css" href="/static/css/bootstrap-select.min.css">
@@ -19,7 +20,7 @@
 
   <div class="container">
 
-    <h4>INDI Web Manager</h4>
+    <h4>{{hostname}} INDI Web Manager</h4>
     <!-- <form> !-->
 
       <div id="firstrow" class="row">


### PR DESCRIPTION
A small add-on showing the hostname in the page heading and the window title. This makes it easier when running multiple INDI servers in parallel.