### PR TITLE
manage indihub-agent process via INDI-server Web Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # INDI Web Manager
 
-INDI Web Manager is a simple Web Application to manage
-[INDI](http://www.indilib.org) server. It supports multiple driver profiles
+INDI Web Manager is a simple Web Application to manage:
+
+- [INDI](http://www.indilib.org) Server
+- [INDIHUB](https://indihub.space) Agent
+
+It supports multiple driver profiles
 along with optional custom remote drivers. It can be used to start INDI server
 locally, and also to connect or **chain** to remote INDI servers.
 
 ![INDI Web Manager](http://indilib.org/images/indi/indiwebmanager.png)
 
 The Web Application is based on [Bottle Py](http://bottlepy.org)
-micro-framework. It has a built-in webserver and by default listens on port
-8624.
+micro-framework. It has a built-in webserver and by default listens on port 8624.
 
 # Installation
 
@@ -291,6 +294,35 @@ All spaces must be encoded with %20 as per URI standards.
 
 **Example:** http://localhost:8624/api/drivers/restart/Pegasus%20UPB
 **Reply:** None
+
+## INDIHUB Agent Methods
+
+### Change indihub-agent current mode
+
+You can launch [indihub-agent](https://github.com/indihub-space/agent) in three different modes or stop it with using this endpoint.
+
+URL | Method | Return | Format
+--- | --- | --- | ---
+/api/indihub/mode/\<mode>| POST | Change indihub-agent to run in a specific mode if INDI server is already running.
+
+Possible values for URI-parameter `mode`:
+- `solo`
+- `share`
+- `robotic`
+- or `off` to stop indihub-agent process
+
+**Example:** curl -X POST /api/indihub/mode/solo
+**Reply:** None
+
+### Get indihub-agent status
+
+URL | Method | Return | Format
+--- | --- | --- | ---
+/api/indihub/status | GET | Get status of `indihub-agent`
+
+**Example:** curl /api/indihub/status
+
+**Reply:** [{'status': 'True', 'mode': 'solo', 'active_profile': 'my-profile'}]
 
 ## System Commands
 

--- a/indiweb/indihub_agent.py
+++ b/indiweb/indihub_agent.py
@@ -18,6 +18,7 @@ if not os.path.exists(INDIHUB_AGENT_CONFIG):
 
 INDIHUB_AGENT_CONFIG += '/indihub.json'
 
+
 class IndiHubAgent(object):
     def __init__(self, web_addr, hostname, port):
         self.__web_addr = web_addr
@@ -29,7 +30,8 @@ class IndiHubAgent(object):
         self.stop()
 
     def __run(self, profile, mode, conf):
-        cmd = 'indihub-agent -indi-server-manager=%s -indi-profile=%s -mode=%s -conf=%s -api-origins=%s > /tmp/indihub-agent.log 2>&1 &' % \
+        cmd = 'indihub-agent -indi-server-manager=%s -indi-profile=%s -mode=%s -conf=%s -api-origins=%s > ' \
+              '/tmp/indihub-agent.log 2>&1 &' % \
               (self.__web_addr, profile, mode, conf,
                '%s:%d,%s.local:%d' % (self.__hostname, self.__port, self.__hostname, self.__port))
         logging.info(cmd)

--- a/indiweb/indihub_agent.py
+++ b/indiweb/indihub_agent.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+
+import os
+import logging
+from subprocess import call
+import psutil
+
+INDIHUB_AGENT_OFF = 'off'
+INDIHUB_AGENT_DEFAULT_MODE = 'solo'
+
+try:
+    INDIHUB_AGENT_CONFIG = os.path.join(os.environ['HOME'], '.indihub')
+except KeyError:
+    INDIHUB_AGENT_CONFIG = '/tmp/indihub'
+
+if not os.path.exists(INDIHUB_AGENT_CONFIG):
+    os.makedirs(INDIHUB_AGENT_CONFIG)
+
+INDIHUB_AGENT_CONFIG += '/indihub.json'
+
+class IndiHubAgent(object):
+    def __init__(self, web_addr, hostname, port):
+        self.__web_addr = web_addr
+        self.__hostname = hostname
+        self.__port = port
+        self.__mode = INDIHUB_AGENT_OFF
+
+        # stop running indihub-agent, if any
+        self.stop()
+
+    def __run(self, profile, mode, conf):
+        cmd = 'indihub-agent -indi-server-manager=%s -indi-profile=%s -mode=%s -conf=%s -api-origins=%s > /tmp/indihub-agent.log 2>&1 &' % \
+              (self.__web_addr, profile, mode, conf,
+               '%s:%d,%s.local:%d' % (self.__hostname, self.__port, self.__hostname, self.__port))
+        logging.info(cmd)
+        call(cmd, shell=True)
+
+    def start(self, profile, mode=INDIHUB_AGENT_DEFAULT_MODE, conf=INDIHUB_AGENT_CONFIG):
+        if self.is_running():
+            self.stop()
+
+        self.__run(profile, mode, conf)
+        self.__mode = mode
+
+    def stop(self):
+        self.__mode = 'off'
+        cmd = ['pkill', '-2', 'indihub-agent']
+        logging.info(' '.join(cmd))
+        ret = call(cmd)
+        if ret == 0:
+            logging.info('indihub-agent terminated successfully')
+        else:
+            logging.warn('terminating indihub-agent failed code ' + str(ret))
+
+    def is_running(self):
+        for proc in psutil.process_iter():
+            if proc.name() == 'indihub-agent':
+                return True
+        return False
+
+    def get_mode(self):
+        return self.__mode

--- a/indiweb/views/form.tpl
+++ b/indiweb/views/form.tpl
@@ -113,8 +113,8 @@
         <div class="col-sm-6">
             <div class="form-group">
                 <label class="control-label">Poweroff Reboot:</label>
-                <button id="system_reboot" onClick="rebootSystem()" class="btn btn-default"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span> Reboot remote System</button>
-                <button id="system_poweroff" onClick="poweroffSystem()" class="btn btn-default"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span> PowerOff remote System</button>
+                <button id="system_reboot" onClick="rebootSystem()" class="btn btn-default" data-toggle="tooltip" title="Reboot remote System"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span></button>
+                <button id="system_poweroff" onClick="poweroffSystem()" class="btn btn-default" data-toggle="tooltip" title="PowerOff remote System"><span class="glyphicon glyphicon-off" aria-hidden="true"></span></button>
                 <div id="notify_system_message"></div>
             </div>
         </div>
@@ -125,33 +125,41 @@
   <br />
 
   <div class="container">
-    <h4>INDIHUB Network Agent Control</h4>
+    <h4>INDIHUB Network Agent Control <a href="https://indihub.space" target="_blank"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span></a></h4>
     <div class="row">
       <div class="col-sm-6">
           <label>Agent Mode:</label>
           <div class="form-check">
-              <input class="form-check-input" type="radio" name="mode" id="mode_off" value="off" checked>
-              <label class="form-check-label" for="mode_off">
-                  Off <span class="notbold">- agent is not running</span>
-              </label>
+              <span data-toggle="tooltip" title="Agent is not running">
+                  <input class="form-check-input" type="radio" name="mode" id="mode_off" value="off" checked>
+                  <label class="form-check-label" for="mode_off">
+                      Off
+                  </label>
+              </span>
           </div>
           <div class="form-check">
-              <input class="form-check-input" type="radio" name="mode" id="mode_solo" value="solo">
-              <label class="form-check-label" for="mode_solo">
-                  Solo <span class="notbold">- equipment sharing is not available, contribute images</span>
-              </label>
+              <span data-toggle="tooltip" title="Equipment sharing is not available, contribute images">
+                  <input class="form-check-input" type="radio" name="mode" id="mode_solo" value="solo">
+                  <label class="form-check-label" for="mode_solo">
+                      Solo
+                  </label>
+              </span>
           </div>
           <div class="form-check">
-              <input class="form-check-input" type="radio" name="mode" id="mode_share" value="share">
-              <label class="form-check-label" for="mode_share">
-                  Share <span class="notbold">- share your equipment and open remote access to your guests</span>
-              </label>
+              <span data-toggle="tooltip" title="Share your equipment and open remote access to your guests">
+                  <input class="form-check-input" type="radio" name="mode" id="mode_share" value="share">
+                  <label class="form-check-label" for="mode_share">
+                      Share
+                  </label>
+              </span>
           </div>
           <div class="form-check">
-              <input class="form-check-input" type="radio" name="mode" id="mode_robotic" value="robotic">
-              <label class="form-check-label" for="mode_robotic">
-                  Robotic <span class="notbold">- your equipment is operated by smart scheduler in the cloud</span>
-              </label>
+              <span data-toggle="tooltip" title="Your equipment is operated by smart scheduler in the cloud">
+                  <input class="form-check-input" type="radio" name="mode" id="mode_robotic" value="robotic">
+                  <label class="form-check-label" for="mode_robotic">
+                      Robotic
+                  </label>
+              </span>
           </div>
           <button id="agent_command" onClick="changeAgentMode()" class="btn btn-default"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span> Change Mode</button>
       </div>
@@ -162,7 +170,6 @@
         </div>
       </div>
     </div>
-    <h4>Learn more about INDIHUB network at <a href="https://indihub.space" target="_blank">indihub.space</a></h4>
   </div>
 
 

--- a/indiweb/views/form.tpl
+++ b/indiweb/views/form.tpl
@@ -14,7 +14,11 @@
   <link rel="stylesheet" type="text/css" href="/static/css/jquery-ui.min.css">
   <link rel="stylesheet" type="text/css" href="/static/css/bootstrap-select.min.css">
   <link rel="stylesheet" type="text/css" href="/static/css/schoolhouse.css">
-
+  <style>
+      .notbold{
+          font-weight:normal
+      }
+  </style>
 </head>
 <body>
 
@@ -96,14 +100,6 @@
 
             <button id="server_command" onClick="toggleServer()" class="btn btn-default"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span> Start</button>
             <div id="notify_message"></div>
-            
-            <div class="col-sm-6">
-                <label for="rebootShutdown" class="control-label">Poweroff Reboot:</label>
-                <button id="system_reboot" onClick="rebootSystem()" class="btn btn-default"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span> Reboot remote System</button>
-                <div id="notify_message"></div>
-                <button id="system_poweroff" onClick="poweroffSystem()" class="btn btn-default"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span> PowerOff remote System</button>
-                <div id="notify_message"></div>
-            </div>
         </div>
         <div class="col-sm-6">
             <div class="form-group">
@@ -113,13 +109,61 @@
         </div>
     </div>
 
-
     <div class="row">
-
+        <div class="col-sm-6">
+            <div class="form-group">
+                <label class="control-label">Poweroff Reboot:</label>
+                <button id="system_reboot" onClick="rebootSystem()" class="btn btn-default"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span> Reboot remote System</button>
+                <button id="system_poweroff" onClick="poweroffSystem()" class="btn btn-default"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span> PowerOff remote System</button>
+                <div id="notify_system_message"></div>
+            </div>
+        </div>
     </div>
+  </div>
 
-   </div>
-</div>
+  <br />
+  <br />
+
+  <div class="container">
+    <h4>INDIHUB Network Agent Control</h4>
+    <div class="row">
+      <div class="col-sm-6">
+          <label>Agent Mode:</label>
+          <div class="form-check">
+              <input class="form-check-input" type="radio" name="mode" id="mode_off" value="off" checked>
+              <label class="form-check-label" for="mode_off">
+                  Off <span class="notbold">- agent is not running</span>
+              </label>
+          </div>
+          <div class="form-check">
+              <input class="form-check-input" type="radio" name="mode" id="mode_solo" value="solo">
+              <label class="form-check-label" for="mode_solo">
+                  Solo <span class="notbold">- equipment sharing is not available, contribute images</span>
+              </label>
+          </div>
+          <div class="form-check">
+              <input class="form-check-input" type="radio" name="mode" id="mode_share" value="share">
+              <label class="form-check-label" for="mode_share">
+                  Share <span class="notbold">- share your equipment and open remote access to your guests</span>
+              </label>
+          </div>
+          <div class="form-check">
+              <input class="form-check-input" type="radio" name="mode" id="mode_robotic" value="robotic">
+              <label class="form-check-label" for="mode_robotic">
+                  Robotic <span class="notbold">- your equipment is operated by smart scheduler in the cloud</span>
+              </label>
+          </div>
+          <button id="agent_command" onClick="changeAgentMode()" class="btn btn-default"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span> Change Mode</button>
+      </div>
+      <div class="col-sm-6">
+        <div class="form-group">
+          <label>Agent Status</label>
+          <div id="agent_notify" class="well">Off</div>
+        </div>
+      </div>
+    </div>
+    <h4>Learn more about INDIHUB network at <a href="https://indihub.space" target="_blank">indihub.space</a></h4>
+  </div>
 
 
 <script src="/static/js/jquery.min.js"></script>

--- a/indiweb/views/js/indi.js
+++ b/indiweb/views/js/indi.js
@@ -370,6 +370,10 @@ function restartDriver(label) {
  }
 
 function rebootSystem() {
+    if (!confirm("Please press OK to confirm remote system Reboot")) {
+        return;
+    }
+
     $.ajax({
         type: 'POST',
         url: "/api/system/reboot",
@@ -383,6 +387,10 @@ function rebootSystem() {
 }
 
 function poweroffSystem() {
+    if (!confirm("Please press OK to confirm remote system Poweroff")) {
+        return;
+    }
+
     $.ajax({
         type: 'POST',
         url: "/api/system/poweroff",

--- a/indiweb/views/js/indi.js
+++ b/indiweb/views/js/indi.js
@@ -5,6 +5,7 @@ $(function()
 
     loadCurrentProfileDrivers();
     getStatus();
+    getIndihubStatus()
 
     $("#drivers_list").change(function() {
         var name = $("#profiles option:selected").text();
@@ -246,12 +247,28 @@ function toggleServer() {
             success: function() {
                 //console.log("INDI Server stopped!");
                 getStatus();
+                getIndihubStatus(); // when INDI-server stops - INDIHUB-agent stops as well
             },
             error: function() {
                 alert('Failed to stop INDI server.');
             }
         });
     }
+}
+
+function changeAgentMode() {
+    var mode = $("input[name='mode']:checked").val();
+    $.ajax({
+        type: 'POST',
+        url: "/api/indihub/mode/" + mode,
+        success: function(data) {
+            getIndihubStatus();
+        },
+        error: function(xhr, status, error) {
+            alert('Failed to change INDIHUB Agent mode: ' + xhr.responseJSON.message);
+            getIndihubStatus();
+        }
+    });
 }
 
 function getStatus() {
@@ -263,6 +280,51 @@ function getStatus() {
             $("#server_notify").html("<p class='alert alert-success'>Server is offline.</p>");
         }
 
+    });
+}
+
+function getIndihubStatus() {
+    $.ajax({
+        type: "GET",
+        url: "/api/indihub/status",
+        success: function(data) {
+            if (data[0].status != "True") {
+                $("#agent_notify").html("<p class='alert alert-success'>Agent is offline.</p>");
+                $("#mode_off").prop('checked', true)
+                return
+            }
+            var msg = "<p class='alert alert-info'>Agent is Online in " + data[0].mode +"-mode</p>";
+            $("#agent_notify").html(msg);
+            $("#mode_"+ data[0].mode).prop('checked', true)
+
+            // for share-mode: get extended status info with public endpoints
+            if (data[0].mode == "share") {
+                // optimistically - agent should be running and listening in no more than 3 sec
+                // (users can always refresh the page to get Agent status loaded)
+                setTimeout(getIndihubAgentStatus, 3000)
+            }
+        }
+    });
+}
+
+function getIndihubAgentStatus() {
+    $.ajax({
+        type: "GET",
+        url: "http://" + document.location.hostname + ":2020/status",
+        success: function(data) {
+            var msg = $("#agent_notify").html();
+            if (data.mode == "share") {
+                msg += "<ul>";
+                for (var i = 0; i < data.publicEndpoints.length; i++) {
+                    msg += "<li>" + data.publicEndpoints[i].name + ": <b>" + data.publicEndpoints[i].addr + "</b></li>";
+                }
+                msg += "</ul>";
+            }
+            $("#agent_notify").html(msg);
+        },
+        error: function(xhr, status, error) {
+            alert("Could not load Agent data, please try to refresh the page!")
+        }
     });
 }
 
@@ -307,12 +369,12 @@ function restartDriver(label) {
         });
  }
 
-function rebootSystem(){
+function rebootSystem() {
     $.ajax({
         type: 'POST',
         url: "/api/system/reboot",
         success: function(){
-            $("#notify_message").html('<br/><div class="alert alert-success"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Reboot system succeeded.</div>');
+            $("#notify_system_message").html('<br/><div class="alert alert-success"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Reboot system succeeded.</div>');
         },
         error: function(){
             alert('Rebooting system failed!');
@@ -320,19 +382,17 @@ function rebootSystem(){
     });
 }
 
-function poweroffSystem()
-{
-        $.ajax(
+function poweroffSystem() {
+    $.ajax({
+        type: 'POST',
+        url: "/api/system/poweroff",
+        success: function()
         {
-            type: 'POST',
-            url: "/api/system/poweroff",
-            success: function()
-            {
-                $("#notify_message").html('<br/><div class="alert alert-success"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>SPoweroff system succeeded.</div>');
-            },
-            error: function()
-            {
-                alert('Poweroff remote system failed!');
-            }
-        });
+            $("#notify_system_message").html('<br/><div class="alert alert-success"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Poweroff system succeeded.</div>');
+        },
+        error: function()
+        {
+            alert('Poweroff remote system failed!');
+        }
+    });
 }

--- a/indiweb/views/js/indi.js
+++ b/indiweb/views/js/indi.js
@@ -5,7 +5,7 @@ $(function()
 
     loadCurrentProfileDrivers();
     getStatus();
-    getIndihubStatus()
+    getIndihubStatus();
 
     $("#drivers_list").change(function() {
         var name = $("#profiles option:selected").text();
@@ -290,18 +290,18 @@ function getIndihubStatus() {
         success: function(data) {
             if (data[0].status != "True") {
                 $("#agent_notify").html("<p class='alert alert-success'>Agent is offline.</p>");
-                $("#mode_off").prop('checked', true)
-                return
+                $("#mode_off").prop('checked', true);
+                return;
             }
             var msg = "<p class='alert alert-info'>Agent is Online in " + data[0].mode +"-mode</p>";
             $("#agent_notify").html(msg);
-            $("#mode_"+ data[0].mode).prop('checked', true)
+            $("#mode_"+ data[0].mode).prop('checked', true);
 
             // for share-mode: get extended status info with public endpoints
             if (data[0].mode == "share") {
                 // optimistically - agent should be running and listening in no more than 3 sec
                 // (users can always refresh the page to get Agent status loaded)
-                setTimeout(getIndihubAgentStatus, 3000)
+                setTimeout(getIndihubAgentStatus, 3000);
             }
         }
     });
@@ -323,7 +323,7 @@ function getIndihubAgentStatus() {
             $("#agent_notify").html(msg);
         },
         error: function(xhr, status, error) {
-            alert("Could not load Agent data, please try to refresh the page!")
+            alert("Could not load Agent data, please try to refresh the page!");
         }
     });
 }


### PR DESCRIPTION
This PR includes new API-endpoints and WEB-UI changes to control indihub-agent process. 

The `indihub-agent` is an optional process which can be run on the side of the `indiserver` process and can be stopped at any moment without affecting `indiserver` process.

However, if `indiserver` process is stopped this will lead to be `indihub-agent` process stopped as well as indihub-agent needs INDI-server to keep running.

New API endpoints:
- `GET /api/indihub/status` - to get indihub-agent status
- `POST /api/indihub/mode/<mode>` - to change indihub-agent running mode with supported values for `<mode>` param as `off`, `solo`, `share`, `robotic`

Web-UI flow changes:

1. INDI-Server is Off, it is not possible to run indihub-agent without INDI-Server 
<img width="1159" alt="Screen Shot 2020-03-08 at 1 07 08 PM" src="https://user-images.githubusercontent.com/33698537/76229317-62777100-61f8-11ea-92f5-3109512ada3d.png">

2. INDI-Server is running but indihub-agent is switched off (not running) 
<img width="1174" alt="Screen Shot 2020-03-08 at 1 06 22 PM" src="https://user-images.githubusercontent.com/33698537/76229081-0ca2c900-61f8-11ea-86ea-80dc6c964797.png">

3. Run indihub-agent in some mode (i.e. `share`-mode) when INDI-Server is running
<img width="1176" alt="Screen Shot 2020-03-08 at 1 07 49 PM" src="https://user-images.githubusercontent.com/33698537/76229498-b1bda180-61f8-11ea-925c-6e31e870bea4.png">

4. Stop indihub-agent (switch to `off`-mode) while keep INDI-Server running
<img width="1178" alt="Screen Shot 2020-03-08 at 1 08 12 PM" src="https://user-images.githubusercontent.com/33698537/76229672-f5b0a680-61f8-11ea-85d7-d9a43a965aaa.png">
