### PR TITLE
Bug fix for Safari that does not recognize onClick

### DIFF
--- a/indiweb/views/form.tpl
+++ b/indiweb/views/form.tpl
@@ -32,7 +32,7 @@
         <div class="form-group">
          <label>Equipment Profile:</label>
          <div class="input-group">
-           <select onClick="loadCurrentProfileDrivers()" id="profiles" class="form-control">
+           <select onchange="loadCurrentProfileDrivers()" id="profiles" class="form-control">
 %for profile in profiles:
     %if saved_profile == profile['name']:
         <option selected>{{profile['name']}}</option>


### PR DESCRIPTION
Safari seems to have a problem with the onClick event inside of a HTML <select> element. As a consequence, when changing the equipment profile, the driver selection are not updated - which is very confusing.

Replacing it by "onchanged" solves the problem.