### PR TITLE
Allow INDI_DATA_DIR to be overriden by an environment variable

### DIFF
--- a/indiweb/driver.py
+++ b/indiweb/driver.py
@@ -5,7 +5,7 @@ import logging
 import xml.etree.ElementTree as ET
 
 # Default INDI data directory
-INDI_DATA_DIR = "/usr/share/indi/"
+INDI_DATA_DIR = os.environ.get('INDI_DATA_DIR', "/usr/share/indi/")
 
 
 class DeviceDriver:


### PR DESCRIPTION
Allow INDI_DATA_DIR to be overriden by an environment variable when indi is not installed to the default filesystem paths.