### PR TITLE
Add option to run reboot/poweroff with sudo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/**
 /build
 /dist
 .idea
+.venv

--- a/indiweb/main.py
+++ b/indiweb/main.py
@@ -374,7 +374,7 @@ def system_reboot():
     logging.info('System reboot, stopping server...')
     stop_server()
     logging.info('rebooting...')
-    subprocess.run("sudo reboot" if args.sudo else "reboot")
+    subprocess.run(["sudo", "reboot"] if args.sudo else "reboot")
 
 
 @app.post('/api/system/poweroff')
@@ -383,7 +383,7 @@ def system_poweroff():
     logging.info('System poweroff, stopping server...')
     stop_server()
     logging.info('poweroff...')
-    subprocess.run("sudo poweroff" if args.sudo else "poweroff")
+    subprocess.run(["sudo", "poweroff"] if args.sudo else "poweroff")
 
 ###############################################################################
 # INDIHUB Agent control endpoints

--- a/indiweb/main.py
+++ b/indiweb/main.py
@@ -49,6 +49,8 @@ parser.add_argument('--verbose', '-v', action='store_true',
 parser.add_argument('--logfile', '-l', help='log file name')
 parser.add_argument('--server', '-s', default='standalone',
                     help='HTTP server [standalone|apache] (default: standalone')
+parser.add_argument('--sudo', '-S', action='store_true',                    
+                    help='Run poweroff/reboot commands with sudo')
 
 args = parser.parse_args()
 
@@ -372,7 +374,7 @@ def system_reboot():
     logging.info('System reboot, stopping server...')
     stop_server()
     logging.info('rebooting...')
-    subprocess.call('reboot')
+    subprocess.run("sudo reboot" if args.sudo else "reboot")
 
 
 @app.post('/api/system/poweroff')
@@ -381,7 +383,7 @@ def system_poweroff():
     logging.info('System poweroff, stopping server...')
     stop_server()
     logging.info('poweroff...')
-    subprocess.run("poweroff")
+    subprocess.run("sudo poweroff" if args.sudo else "poweroff")
 
 ###############################################################################
 # INDIHUB Agent control endpoints


### PR DESCRIPTION
I am using indi-web on a mini PC running Ubuntu Server 22.04. I am starting indi-web automatically using systemd under a non-root user. Furthermore, I really want to use the reboot and power off buttons in the web interface instead of accessing the machine via SSH to power it down. However, the buttons do not work for my setup (and probably a lot of other users):

Running either `reboot` or `poweroff` will not work with a non-root user unless you use sudo and hitting the reboot/poweroff buttons in the web interface result in these error messages and now reboot/power off happening:

```
Failed to set wall message, ignoring: Interactive authentication required.
Failed to power off system via logind: Interactive authentication required.
Failed to open initctl fifo: Permission denied
Failed to talk to init daemon.
```

I've allowed the user to execute `reboot` and `poweroff` using sudo without entering a password by running `sudo visudo` and adding these two lines:

```
indiweb ALL=(ALL) NOPASSWD:/usr/sbin/poweroff
indiweb ALL=(ALL) NOPASSWD:/usr/sbin/reboot
```

Now running either `sudo reboot` or `sudo poweroff` in the terminal with that user reboots or shuts down the machine without asking for a password. 

What was left now is to make indi-web execute these commands using `sudo` as well. Because I don't think it's a great idea to always run the commands with sudo (e.g. when the service is running as root) therefore I've added a command line flag to enable or disable this behavior.

To make everything work, I am using this configuration for the systemd service, notice the `-S` flag (`--sudo` works as well):

```
[Unit]
Description=INDI Web Manager
After=multi-user.target

[Service]
Type=idle
User=indiweb
ExecStart=/usr/local/bin/indi-web -v -S
Restart=always
RestartSec=5

[Install]
WantedBy=multi-user.target
```

Now the reboot and power off button in the web interface work correctly for me and allow me to shut down my system after an imaging session without accessing it via SSH.