### PR TITLE
Fixing __async_cmd causing exception.

### DIFF
--- a/indiweb/indihub_agent.py
+++ b/indiweb/indihub_agent.py
@@ -25,6 +25,7 @@ class IndiHubAgent(object):
         self.__hostname = hostname
         self.__port = port
         self.__mode = INDIHUB_AGENT_OFF
+        self.__async_cmd = None
 
     def __run(self, profile, mode, conf):
         cmd = 'indihub-agent -indi-server-manager=%s -indi-profile=%s -mode=%s -conf=%s -api-origins=%s > ' \
@@ -45,6 +46,9 @@ class IndiHubAgent(object):
 
     def stop(self):
         # Terminate will also kill the child processes like the drivers
+        if not self.__async_cmd:
+            logging.info('indihub_agent: not running')
+            return
         try:
             self.__async_cmd.terminate()
             self.__command_thread.join()
@@ -54,10 +58,9 @@ class IndiHubAgent(object):
             logging.info('indihub_agent: terminated successfully')
 
     def is_running(self):
-        if self.__async_cmd:
-            return self.__async_cmd.is_running()
-        else:
+        if not self.__async_cmd:
             return False
+        return self.__async_cmd.is_running()
 
     def get_mode(self):
         return self.__mode


### PR DESCRIPTION
**Issue:**
```
Feb 28 21:24:52 astropi1 indi-web[2743]: 2024-02-28 21:24:52,016 - INFO: using Bottle as standalone server
Feb 28 21:28:38 astropi1 indi-web[2743]: Traceback (most recent call last):
Feb 28 21:28:38 astropi1 indi-web[2743]:   File "/home/jrhuerta/indiweb/bin/bottle.py", line 876, in _handle
Feb 28 21:28:38 astropi1 indi-web[2743]:     return route.call(**args)
Feb 28 21:28:38 astropi1 indi-web[2743]:            ^^^^^^^^^^^^^^^^^^
Feb 28 21:28:38 astropi1 indi-web[2743]:   File "/home/jrhuerta/indiweb/bin/bottle.py", line 1759, in wrapper
Feb 28 21:28:38 astropi1 indi-web[2743]:     rv = callback(*a, **ka)
Feb 28 21:28:38 astropi1 indi-web[2743]:          ^^^^^^^^^^^^^^^^^^
Feb 28 21:28:38 astropi1 indi-web[2743]:   File "/home/jrhuerta/indiweb/lib/python3.11/site-packages/indiweb/main.py", line 395, in get_indihub_status
Feb 28 21:28:38 astropi1 indi-web[2743]:     is_running = indihub_agent.is_running()
Feb 28 21:28:38 astropi1 indi-web[2743]:                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
Feb 28 21:28:38 astropi1 indi-web[2743]:   File "/home/jrhuerta/indiweb/lib/python3.11/site-packages/indiweb/indihub_agent.py", line 57, in is_running
Feb 28 21:28:38 astropi1 indi-web[2743]:     if self.__async_cmd:
Feb 28 21:28:38 astropi1 indi-web[2743]:        ^^^^^^^^^^^^^^^^
Feb 28 21:28:38 astropi1 indi-web[2743]: AttributeError: 'IndiHubAgent' object has no attribute '_IndiHubAgent__async_cmd'
```

**Cause**
`__async_cmd` is only defined when the hub agent is run, trying to access the attribute like in the `is_running` method if `__run()` has not been executed before leads to an `AttributeError`. 
I ran into this issue when multiple devices are trying to access the same indiweb instance.

**Change Proposal**
Define the attribute in the class constructor to avoid the `AttributeError` exception.