### PR TITLE
Fixing deprecation issue with absolute path templates.

### DIFF
--- a/indiweb/main.py
+++ b/indiweb/main.py
@@ -10,7 +10,17 @@ import subprocess
 import platform
 from importlib_metadata import version
 
-from bottle import Bottle, run, template, static_file, request, response, BaseRequest, default_app
+from bottle import (
+    Bottle,
+    run,
+    template,
+    TEMPLATE_PATH,
+    static_file,
+    request,
+    response,
+    BaseRequest,
+    default_app,
+)
 from .indi_server import IndiServer, INDI_PORT, INDI_FIFO, INDI_CONFIG_DIR
 from .driver import DeviceDriver, DriverCollection, INDI_DATA_DIR
 from .database import Database
@@ -26,6 +36,7 @@ BaseRequest.MEMFILE_MAX = 50 * 1024 * 1024
 
 pkg_path, _ = os.path.split(os.path.abspath(__file__))
 views_path = os.path.join(pkg_path, 'views')
+TEMPLATE_PATH.insert(0, views_path)
 
 parser = argparse.ArgumentParser(
     description='INDI Web Manager. '
@@ -139,9 +150,13 @@ def main_form():
         saved_profile = request.get_cookie('indiserver_profile') or 'Simulators'
 
     profiles = db.get_profiles()
-    return template(os.path.join(views_path, 'form.tpl'), profiles=profiles,
-                    drivers=drivers, saved_profile=saved_profile,
-                    hostname=hostname)
+    return template(
+        "form.tpl",
+        profiles=profiles,
+        drivers=drivers,
+        saved_profile=saved_profile,
+        hostname=hostname,
+    )
 
 ###############################################################################
 # Profile endpoints

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.32.2
 psutil==6.0.0
 bottle==0.12.25
+importlib_metadata==8.5.0


### PR DESCRIPTION
indiweb manager stopped working because templates can not be referenced with absolute paths anymore.

```bash
Traceback (most recent call last):
  File "/home/jrhuerta/Code/indiwebmanager/.venv/lib/python3.9/site-packages/bottle-0.13.2-py3.9.egg/EGG-INFO/scripts/bottle.py", line 995, in _handle
    out = route.call(**args)
  File "/home/jrhuerta/Code/indiwebmanager/.venv/lib/python3.9/site-packages/bottle-0.13.2-py3.9.egg/EGG-INFO/scripts/bottle.py", line 2025, in wrapper
    rv = callback(*a, **ka)
  File "/home/jrhuerta/Code/indiwebmanager/.venv/lib/python3.9/site-packages/indiweb-0.1.8-py3.9.egg/indiweb/main.py", line 142, in main_form
    return template(os.path.join(views_path, 'form.tpl'), profiles=profiles,
  File "/home/jrhuerta/Code/indiwebmanager/.venv/lib/python3.9/site-packages/bottle-0.13.2-py3.9.egg/EGG-INFO/scripts/bottle.py", line 4493, in template
    TEMPLATES[tplid] = adapter(name=tpl, lookup=lookup, **settings)
  File "/home/jrhuerta/Code/indiwebmanager/.venv/lib/python3.9/site-packages/bottle-0.13.2-py3.9.egg/EGG-INFO/scripts/bottle.py", line 4076, in __init__
    self.filename = self.search(self.name, self.lookup)
  File "/home/jrhuerta/Code/indiwebmanager/.venv/lib/python3.9/site-packages/bottle-0.13.2-py3.9.egg/EGG-INFO/scripts/bottle.py", line 4091, in search
    raise depr(0, 12, "Use of absolute path for template name.",
DeprecationWarning: Warning: Use of deprecated feature or API. (Deprecated in Bottle-0.12)
Cause: Use of absolute path for template name.
Fix: Refer to templates with names or paths relative to the lookup path.
```